### PR TITLE
Fix crash when logout ws event races an already-invalidated session

### DIFF
--- a/Stoat/ViewState.swift
+++ b/Stoat/ViewState.swift
@@ -825,7 +825,10 @@ public class ViewState: ObservableObject {
             case .error(let e):
                 print(e.data)
             case .logout:
-                try! await signOut().get()
+                if case .failure = await signOut() {
+                    self.ws?.stop()
+                    setSignedOutState()
+                }
             case .pong(let e):
                 print("ponog")
             case .message_remove_reaction(let e):


### PR DESCRIPTION
Signing out crashes the app: the server pushes a logout ws event after the session was already invalidated by the explicit sign-out request.