### PR TITLE
fix: Avoid redundant isOnboarding publish crashing the sign-out transition

### DIFF
--- a/Stoat/Pages/Login/Welcome.swift
+++ b/Stoat/Pages/Login/Welcome.swift
@@ -113,7 +113,9 @@ struct Welcome: View {
                 }
             }
             .onAppear {
-                viewState.isOnboarding = false
+                if viewState.isOnboarding {
+                    viewState.isOnboarding = false
+                }
             }
             .task {
                 viewState.apiInfo = try? await viewState.http.fetchApiInfo().get()


### PR DESCRIPTION
During the sign-out transition, Welcome's onAppear unconditionally sets viewState.isOnboarding = false

Guarding the assignment (it is already false in this flow) removes the redundant publish and the crash.